### PR TITLE
Slack: Add filtering of slack messages with start date and end date

### DIFF
--- a/musicrs/util/date_time.py
+++ b/musicrs/util/date_time.py
@@ -1,0 +1,18 @@
+"""
+Date time utilities
+"""
+from datetime import datetime
+
+
+def timestamp_to_datetime(ts):
+    """ Convert timestamp to datetime """
+    return datetime.fromtimestamp(ts)
+
+
+def datetime_to_timestamp(dt):
+    """
+    Convert datetime to timestamp
+    param dt: datetime
+    type dt: <class 'datetime.datetime'>
+    """
+    return datetime.timestamp(dt)

--- a/musicrs/util/date_time.py
+++ b/musicrs/util/date_time.py
@@ -4,15 +4,21 @@ Date time utilities
 from datetime import datetime
 
 
-def timestamp_to_datetime(ts):
-    """ Convert timestamp to datetime """
-    return datetime.fromtimestamp(ts)
+def timestamp_to_date(ts):
+    """
+    Convert timestamp to date.
+    :param ts: timestamp
+    :type ts: float
+    """
+    date = datetime.fromtimestamp(ts).date()
+    return date.strftime("%Y-%m-%d")
 
 
-def datetime_to_timestamp(dt):
+def date_to_timestamp(date):
     """
-    Convert datetime to timestamp
-    param dt: datetime
-    type dt: <class 'datetime.datetime'>
+    Convert date to timestamp.
+    :param date: date (%Y-%m-%d) e.g 1970-01-01
+    :type date: str
     """
+    dt = datetime.strptime(date, "%Y-%m-%d")  # convert to datetime
     return datetime.timestamp(dt)

--- a/musicrs/util/slack_api.py
+++ b/musicrs/util/slack_api.py
@@ -5,20 +5,27 @@ import os
 import json
 import slack
 import musicrs.settings as settings
+from musicrs.util.date_time import *
 
 SLACK_API_TOKEN = settings.SLACK_API_TOKEN
 slackClient = slack.WebClient(token=SLACK_API_TOKEN)
 
 
-def retrieve_slack_messages(channel: str):
+def retrieve_slack_messages(channel: str, start_date: str, end_date: str):
     """
     Retrieve youtube links from slack channel
     :param channel: Slack channel id
     :type channel: string
+    :param start_date: str (YYYY-mm-dd)
+    :param end_date: str (YYYY-mm-dd)
     :return slack channel messages
     :rtype list
     """
-    response = slackClient.conversations_history(channel=channel)
+
+    oldest = date_to_timestamp(start_date)
+    latest = date_to_timestamp(end_date)
+
+    response = slackClient.conversations_history(channel=channel, latest=str(latest), oldest=str(oldest))
     retrieved_messages = []
 
     for message in response["messages"]:


### PR DESCRIPTION
# Description
- Add date and timestamp utilities.
- Add filtering of slack messages with the start date and the end date.

# Usage
retrieve_slack_messages(channel, start_date, end_date)

channel: str: slack channel id
start_date: str: YYYY-mm-dd (e.g: 1970-01-01)
end_date: str: YYYY-mm-dd