### PR TITLE
Slack: Integrate user info with slack messages

### DIFF
--- a/musicrs/util/slack_api.py
+++ b/musicrs/util/slack_api.py
@@ -11,6 +11,24 @@ SLACK_API_TOKEN = settings.SLACK_API_TOKEN
 slackClient = slack.WebClient(token=SLACK_API_TOKEN)
 
 
+def get_user_info(user_id):
+    """
+    Retrieve slack user info from user id
+    :param user_id: slack id of the user
+    :type user_id: string
+    """
+    response = slackClient.users_info(user=user_id)
+    profile = response["user"]["profile"]
+    user_info = {
+        "user_display_name": profile["display_name"],
+        "user_real_name": profile["real_name"],
+        "user_email": profile["email"],
+        "user_profile_picture": profile["image_512"],
+    }
+
+    return user_info
+
+
 def retrieve_slack_messages(channel: str, start_date: str, end_date: str):
     """
     Retrieve youtube links from slack channel
@@ -25,7 +43,9 @@ def retrieve_slack_messages(channel: str, start_date: str, end_date: str):
     oldest = date_to_timestamp(start_date)
     latest = date_to_timestamp(end_date)
 
-    response = slackClient.conversations_history(channel=channel, latest=str(latest), oldest=str(oldest))
+    response = slackClient.conversations_history(
+        channel=channel, latest=str(latest), oldest=str(oldest)
+    )
     retrieved_messages = []
 
     for message in response["messages"]:
@@ -39,8 +59,8 @@ def retrieve_slack_messages(channel: str, start_date: str, end_date: str):
                 attached_song = message["attachments"][0]
                 song = {
                     "song_title": attached_song["title"],
-                    "song_author": attached_song["author_name"],
                     "song_url": attached_song["original_url"],
+                    "youtube_channel": attached_song["author_name"],
                 }
 
                 retrieved_message.update(song)

--- a/musicrs/util/slack_api.py
+++ b/musicrs/util/slack_api.py
@@ -64,6 +64,7 @@ def retrieve_slack_messages(channel: str, start_date: str, end_date: str):
                 }
 
                 retrieved_message.update(song)
+                retrieved_message.update(get_user_info(message["user"]))
                 retrieved_messages.append(retrieved_message)
 
     return retrieved_messages


### PR DESCRIPTION
# Description
- Add function to get user info
- Integrate user info with slack messages
- Change `song_author` to `youtube_channel` field.

### Following new fields have been added:
- user_display_name,
- user_real_name,
- user_email,
- user_profile_picture,
- youtube_channel

<b>Note:</b> display_name is slack username, and real_name is actual first and last name of the user.